### PR TITLE
Fix Exec format error with s6 docker image

### DIFF
--- a/root/etc/cont-init.d/30-defaults.sh
+++ b/root/etc/cont-init.d/30-defaults.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/with-contenv sh
+
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -16,8 +18,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
-#!/usr/bin/with-contenv sh
 
 cp -rn /app/guacamole /config
 mkdir -p /root/.config/freerdp/known_hosts

--- a/root/etc/cont-init.d/40-postgres.sh
+++ b/root/etc/cont-init.d/40-postgres.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/with-contenv sh
+
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -16,8 +18,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
-#!/usr/bin/with-contenv sh
 
 mkdir -p /config/postgres
 mkdir -p /var/run/postgresql 

--- a/root/etc/cont-init.d/50-extensions
+++ b/root/etc/cont-init.d/50-extensions
@@ -1,3 +1,5 @@
+#!/usr/bin/with-contenv sh
+
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -16,8 +18,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
-#!/usr/bin/with-contenv sh
 
 # clean up extensions
 for i in auth-ldap auth-duo auth-header auth-cas auth-openid auth-quickconnect auth-totp; do

--- a/root/etc/services.d/guacamole/run
+++ b/root/etc/services.d/guacamole/run
@@ -1,3 +1,5 @@
+#!/usr/bin/with-contenv sh
+
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -16,8 +18,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
-#!/usr/bin/with-contenv sh
 
 until pg_isready; do
   echo "Waiting for postgres to come up..."

--- a/root/etc/services.d/guacd/run
+++ b/root/etc/services.d/guacd/run
@@ -1,3 +1,5 @@
+#!/usr/bin/with-contenv sh
+
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -16,8 +18,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
-#!/usr/bin/with-contenv sh
 
 echo "Starting guacamole guacd..."
 s6-setuidgid root guacd -f -b 127.0.0.1

--- a/root/etc/services.d/postgres/run
+++ b/root/etc/services.d/postgres/run
@@ -1,3 +1,5 @@
+#!/usr/bin/with-contenv sh
+
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -16,8 +18,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
-#!/usr/bin/with-contenv sh
 
 echo "Starting postgres..."
 s6-setuidgid postgres postgres


### PR DESCRIPTION
Shebang should always be put at the very top.
Last licence addition to s6 scripts prevented that.
s6 failing to start any of them with a "Exec format error" error message.
This PR simply put back the shebang at the very top in impacted files.